### PR TITLE
Update to use touchbar-registry

### DIFF
--- a/keymaps/touchbar.json
+++ b/keymaps/touchbar.json
@@ -1,5 +1,2 @@
 {
-  "atom-workspace": {
-    "ctrl-alt-o": "touchbar:toggle"
-  }
 }

--- a/lib/touchbar-edit-view.js
+++ b/lib/touchbar-edit-view.js
@@ -111,6 +111,7 @@ export default class TouchBarEditView {
 
   remove(i) {
     const oldConfig = JSON.parse(atom.config.get('touchbar.buttons'))
+    const id = oldConfig[i].id;
     oldConfig.splice(i, 1)
     atom.config.set('touchbar.buttons', JSON.stringify(oldConfig))
     etch.update(this)

--- a/lib/touchbar-edit-view.js
+++ b/lib/touchbar-edit-view.js
@@ -111,7 +111,6 @@ export default class TouchBarEditView {
 
   remove(i) {
     const oldConfig = JSON.parse(atom.config.get('touchbar.buttons'))
-    const id = oldConfig[i].id;
     oldConfig.splice(i, 1)
     atom.config.set('touchbar.buttons', JSON.stringify(oldConfig))
     etch.update(this)

--- a/lib/touchbar-ui.js
+++ b/lib/touchbar-ui.js
@@ -161,9 +161,9 @@ export default class TouchbarUi {
         });
         break;
 
-      case "scrubber":
+      case "emoji":
         return new TouchBarScrubber({
-          items: emojis,
+          items: emojis.map(e => this.createTouchBarElement(e)),
           select: (i) => {
             atom.workspace.getActiveTextEditor().insertText(emojis[i].label)
           },

--- a/lib/touchbar-ui.js
+++ b/lib/touchbar-ui.js
@@ -1,0 +1,177 @@
+'use babel';
+
+const { TouchBar, nativeImage } = require('remote')
+const {
+  TouchBarButton,
+  TouchBarColorPicker,
+  TouchBarGroup,
+  TouchBarLabel,
+  TouchBarPopover,
+  TouchBarScrubber,
+  TouchBarSegmentedControl,
+  TouchBarSlider,
+  TouchBarSpacer
+} = TouchBar;
+
+const emojis = require('./emoji.json');
+const colorRegEx = new RegExp('#[A-Fa-f0-9]{6}');
+
+export default class TouchbarUi {
+  constructor() {
+    this.itemIds = [];
+  }
+
+  dispose() {}
+
+  attachRegistry(registry) {
+    this.registry = registry;
+
+    this.updateItems(atom.config.get('touchbar.buttons'));
+  }
+
+  updateItems(serializedItems) {
+    const items = this.createTouchBarItems(serializedItems);
+    this.renderItems(items);
+  }
+
+  renderItems(items) {
+    for (let itemId of this.itemIds) {
+      this.registry.removeItem(itemId);
+    }
+
+    for (let item of items) {
+      const id = this.registry.addItem(item, 100);
+      this.itemIds.push(id);
+    }
+  }
+
+  createTouchBarItems(input) {
+    const elements = typeof input === 'string' ? JSON.parse(input) : input;
+
+    // map all touch bar elements from config and create equivalent objects
+    return elements.map(e => this.createTouchBarElement(e));
+  }
+
+  createTouchBarElement(e) {
+    switch (e.type) {
+      case "button":
+        let iconColor = null
+        if(e.iconColor === 'white' ) {
+          iconColor = [-1, 0, 1]
+        }
+        if(e.iconColor === 'black' ) {
+          iconColor = [-1, 1, 0]
+        }
+        // creating new button
+        return new TouchBarButton({
+          label: e.label,
+          icon: e.icon ? e.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(e.icon, iconColor) : nativeImage.createFromPath(e.icon) : null,
+          click: () => {
+            var activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
+            atom.commands.dispatch(activeElement, e.command);
+          },
+          // apply selected color only when there is one specified in config, otherwise use default color
+          backgroundColor: (e.color
+            ? e.color
+            : null)
+        });
+        break;
+
+      case "button-insert":
+        let insertIconColor = null
+        if(e.iconColor === 'white' ) {
+          insertIconColor = [-1, 0, 1]
+        }
+        if(e.iconColor === 'black' ) {
+          insertIconColor = [-1, 1, 0]
+        }
+        // creating new button
+        return new TouchBarButton({
+          label: e.label,
+          icon: e.icon ? e.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(e.icon, insertIconColor) : nativeImage.createFromPath(e.icon) : null,
+          click: () => atom.workspace.getActiveTextEditor().insertText(e.command),
+          // apply selected color only when there is one specified in config, otherwise use default color
+          backgroundColor: (e.color
+            ? e.color
+            : null)
+        });
+        break;
+
+      case "label":
+        // creating new label
+        return new TouchBarLabel({label: e.label, textColor: e.color});
+        break;
+
+      case "color-picker":
+        // breating new color picker
+        return new TouchBarColorPicker({
+
+          change: (color) => {
+            // inserts the current selected color
+            // get current cursor position
+            var cbp = atom.workspace.getActiveTextEditor().getCursorBufferPosition()
+            // check if cursor is at beginning of color hex string
+            // otherwise insert 7 spaces that will be replaced with hex string
+            var nextText = atom.workspace.getActiveTextEditor().getTextInBufferRange([[cbp.row, cbp.column], [cbp.row, cbp.column+7]])
+            if(!colorRegEx.test(nextText)) {
+              atom.workspace.getActiveTextEditor().insertText('       ')
+            }
+
+            // insert color string into next 7 range
+            atom.workspace.getActiveTextEditor().setTextInBufferRange([[cbp.row, cbp.column], [cbp.row, cbp.column+7]], color)
+            // set cursor position to begin of color hex code
+            atom.workspace.getActiveTextEditor().setCursorBufferPosition(cbp)
+          }
+        });
+        break;
+
+      case "spacer":
+        // breating new color picker
+        return new TouchBarSpacer({size: e.size});
+        break;
+
+      case "group":
+        return new TouchBarGroup({
+          items: this.createTouchBarItems(e.elements)
+        });
+        break;
+
+      case "segment":
+        return new TouchBarSegmentedControl({
+          segments: e.elements.map(c => ({
+            label: c.label,
+            icon: c.icon ? c.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(c.icon, c.iconColor) : nativeImage.createFromPath(c.icon) : null,
+          }))
+        });
+        break;
+
+      case "popover":
+        let popIconColor = null
+        if(e.iconColor === 'white' ) {
+          iconColor = [-1, 0, 1]
+        }
+        if(e.iconColor === 'black' ) {
+          iconColor = [-1, 1, 0]
+        }
+
+        return new TouchBarPopover({
+          label: e.label,
+          icon: e.icon ? nativeImage.createFromNamedImage(e.icon, popIconColor) : null,
+          items: this.createTouchBarItems(e.elements)
+        });
+        break;
+
+      case "scrubber":
+        return new TouchBarScrubber({
+          items: emojis,
+          select: (i) => {
+            atom.workspace.getActiveTextEditor().insertText(emojis[i].label)
+          },
+          selectedStyle: "outline",
+          overlayStyle: "outline",
+          continuous: false
+        });
+        break;
+    }
+  }
+}

--- a/lib/touchbar-ui.js
+++ b/lib/touchbar-ui.js
@@ -21,7 +21,9 @@ export default class TouchbarUi {
     this.itemIds = [];
   }
 
-  dispose() {}
+  dispose() {
+    this.removeItems();
+  }
 
   attachRegistry(registry) {
     this.registry = registry;
@@ -35,13 +37,17 @@ export default class TouchbarUi {
   }
 
   renderItems(items) {
-    for (let itemId of this.itemIds) {
-      this.registry.removeItem(itemId);
-    }
+    this.removeItems();
 
     for (let item of items) {
       const id = this.registry.addItem(item, 100);
       this.itemIds.push(id);
+    }
+  }
+
+  removeItems() {
+    for (let itemId of this.itemIds) {
+      this.registry.removeItem(itemId);
     }
   }
 

--- a/lib/touchbar.js
+++ b/lib/touchbar.js
@@ -35,9 +35,9 @@ export default {
 
     this.touchbarUi = new TouchbarUi();
 
-    atom.config.onDidChange('touchbar.buttons', ({newValue, oldValue}) => {
+    this.subscriptions.add(atom.config.onDidChange('touchbar.buttons', ({newValue, oldValue}) => {
       this.touchbarUi.updateItems(newValue);
-    });
+    }));
 
     // Register command that opens the edit window
     this.subscriptions.add(atom.commands.add('atom-workspace', {

--- a/lib/touchbar.js
+++ b/lib/touchbar.js
@@ -2,66 +2,42 @@
 
 import TouchbarEditView from './touchbar-edit-view';
 import {CompositeDisposable} from 'atom';
-
-const {app, BrowserWindow, TouchBar, Point, Range, nativeImage} = require('remote')
-
-const {
-  TouchBarButton,
-  TouchBarColorPicker,
-  TouchBarGroup,
-  TouchBarLabel,
-  TouchBarPopover,
-  TouchBarScrubber,
-  TouchBarSegmentedControl,
-  TouchBarSlider,
-  TouchBarSpacer
-} = TouchBar
+import TouchbarUi from './touchbar-ui';
 
 const EditViewURI = 'atom://touchbar-edit-view'
 
-const emojis = require('./emoji.json')
-
-let touchBarEnabled = false;
-
-let globalTouchBar = undefined;
-
-const colorRegEx = new RegExp('#[A-Fa-f0-9]{6}')
-
 export default {
-
-  touchbarView : null,
   modalPanel : null,
   subscriptions : null,
+  touchbarUi: null,
 
   config : {
     buttons: {
       title: 'Elements',
       description: 'Configure your toutchbar elements here',
       type: 'string',
-      default: '[{"type":"label","name":"Config 1524399902796","label":"Atom Touchbar","color":"#e0fcf0"},{"name":"comment-button","type":"button","label":"//","command":"editor:toggle-line-comments","color":"#5712d6","icon":"","iconColor":"default"},{"name":"color-picker","type":"color-picker"},{"name":"spacer","type":"button","size":"small","label":"","command":"tree-view:toggle","color":"#00716c","icon":"NSTouchBarSidebarTemplate","iconColor":"white"},{"name":"toggle-command-palette","type":"button","label":"🎨","command":"command-palette:toggle"},{"type":"popover","label":"😄","elements":[{"name":"emoji-scrubber","type":"scrubber","label":"😄","items":"emojis"}],"command":"","icon":""},{"name":"toggle-github","type":"button","label":"GitHub","color":"#919191","command":"github:toggle-github-tab"},{"name":"edit-touchbar","type":"button","label":"Touchbar","command":"touchbar:edit","color":"#6b2f4f"}]'
+      default: JSON.stringify([
+        {type:"label",name:"Config 1524399902796",label:"Atom Touchbar",color:"#e0fcf0"},
+        {name:"comment-button",type:"button",label:"//",command:"editor:toggle-line-comments",color:"#5712d6",icon:"",iconColor:"default"},
+        {name:"color-picker",type:"color-picker"},
+        {name:"spacer",type:"button",size:"small",label:"",command:"tree-view:toggle",color:"#00716c",icon:"NSTouchBarSidebarTemplate",iconColor:"white"},
+        {name:"toggle-command-palette",type:"button",label:"🎨",command:"command-palette:toggle"},
+        {type:"popover",label:"😄",elements:[{name:"emoji-scrubber",type:"scrubber",label:"😄",items:"emojis"}],command:"",icon:""},
+        {name:"toggle-github",type:"button",label:"GitHub",color:"#919191",command:"github:toggle-github-tab"},
+        {name:"edit-touchbar",type:"button",label:"Touchbar",command:"touchbar:edit",color:"#6b2f4f"}
+      ])
     }
   },
 
-  activate(state) {
+  activate() {
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable();
 
-    const touchBar = this.arrayToTouchBarElements(atom.config.get('touchbar.buttons'));
-
-    globalTouchBar = touchBar
-
-    atom.getCurrentWindow().setTouchBar(touchBar)
-
-    // Register command that toggles this view
-    this.subscriptions.add(atom.commands.add('atom-workspace', {
-      'touchbar:toggle': () => this.toggle()
-    }));
+    this.touchbarUi = new TouchbarUi();
 
     atom.config.onDidChange('touchbar.buttons', ({newValue, oldValue}) => {
-      const touchBar = this.arrayToTouchBarElements(newValue);
-      globalTouchBar = touchBar
-      atom.getCurrentWindow().setTouchBar(touchBar)
-    })
+      this.touchbarUi.updateItems(newValue);
+    });
 
     // Register command that opens the edit window
     this.subscriptions.add(atom.commands.add('atom-workspace', {
@@ -70,157 +46,20 @@ export default {
   },
 
   deactivate() {
-    BrowserWindow.getFocusedWindow().setTouchBar(null)
+    this.touchbarUi.dispose();
     this.modalPanel.destroy();
     this.subscriptions.dispose();
-    this.touchbarView.destroy();
   },
 
   serialize() {
-    // return {touchbarViewState: this.touchbarView.serialize()};
   },
 
-  toggle() {
-    BrowserWindow.getFocusedWindow().setTouchBar(touchBarEnabled
-      ? null
-      : globalTouchBar)
-    touchBarEnabled = !touchBarEnabled
+  consumeTouchBar(touchbarRegistry) {
+    this.touchbarUi.attachRegistry(touchbarRegistry);
   },
 
   openEditWindow() {
     let tbev = new TouchbarEditView(EditViewURI)
     atom.workspace.open(tbev)
-  },
-
-  arrayToTouchBarElements(input) {
-    let elements = typeof input === 'string' ? JSON.parse(input) : input;
-    let myTouchBarElements = []
-
-    // map all touch bar elements from config and create equivalent objects
-    elements.map((e, i) => {
-      switch (e.type) {
-        case "button":
-          let iconColor = null
-          if(e.iconColor === 'white' ) {
-            iconColor = [-1, 0, 1]
-          }
-          if(e.iconColor === 'black' ) {
-            iconColor = [-1, 1, 0]
-          }
-          // creating new button
-          myTouchBarElements.push(new TouchBarButton({
-            label: e.label,
-            icon: e.icon ? e.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(e.icon, iconColor) : nativeImage.createFromPath(e.icon) : null,
-            click: () => {
-              var activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
-              atom.commands.dispatch(activeElement, e.command);
-            },
-            // apply selected color only when there is one specified in config, otherwise use default color
-            backgroundColor: (e.color
-              ? e.color
-              : null)
-          }))
-          break;
-
-        case "button-insert":
-          let insertIconColor = null
-          if(e.iconColor === 'white' ) {
-            insertIconColor = [-1, 0, 1]
-          }
-          if(e.iconColor === 'black' ) {
-            insertIconColor = [-1, 1, 0]
-          }
-          // creating new button
-          myTouchBarElements.push(new TouchBarButton({
-            label: e.label,
-            icon: e.icon ? e.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(e.icon, insertIconColor) : nativeImage.createFromPath(e.icon) : null,
-            click: () => atom.workspace.getActiveTextEditor().insertText(e.command),
-            // apply selected color only when there is one specified in config, otherwise use default color
-            backgroundColor: (e.color
-              ? e.color
-              : null)
-          }))
-          break;
-
-        case "label":
-          // creating new label
-          myTouchBarElements.push(new TouchBarLabel({label: e.label, textColor: e.color}))
-          break;
-
-        case "color-picker":
-          // breating new color picker
-          myTouchBarElements.push(new TouchBarColorPicker({
-
-            change: (color) => {
-              // inserts the current selected color
-              // get current cursor position
-              var cbp = atom.workspace.getActiveTextEditor().getCursorBufferPosition()
-              // check if cursor is at beginning of color hex string
-              // otherwise insert 7 spaces that will be replaced with hex string
-              var nextText = atom.workspace.getActiveTextEditor().getTextInBufferRange([[cbp.row, cbp.column], [cbp.row, cbp.column+7]])
-              if(!colorRegEx.test(nextText)) {
-                atom.workspace.getActiveTextEditor().insertText('       ')
-              }
-
-              // insert color string into next 7 range
-              atom.workspace.getActiveTextEditor().setTextInBufferRange([[cbp.row, cbp.column], [cbp.row, cbp.column+7]], color)
-              // set cursor position to begin of color hex code
-              atom.workspace.getActiveTextEditor().setCursorBufferPosition(cbp)
-            }
-          }))
-          break;
-
-        case "spacer":
-          // breating new color picker
-          myTouchBarElements.push(new TouchBarSpacer({size: e.size}))
-          break;
-
-        case "group":
-          myTouchBarElements.push(new TouchBarGroup({
-            items: this.arrayToTouchBarElements(e.elements)
-          }))
-          break;
-
-        case "segment":
-          myTouchBarElements.push(new TouchBarSegmentedControl({
-            segments: e.elements.map(c => ({
-              label: c.label,
-              icon: c.icon ? c.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(c.icon, c.iconColor) : nativeImage.createFromPath(c.icon) : null,
-            }))
-          }))
-          break;
-
-        case "popover":
-          let popIconColor = null
-          if(e.iconColor === 'white' ) {
-            iconColor = [-1, 0, 1]
-          }
-          if(e.iconColor === 'black' ) {
-            iconColor = [-1, 1, 0]
-          }
-
-          myTouchBarElements.push(new TouchBarPopover({
-            label: e.label,
-            icon: e.icon ? nativeImage.createFromNamedImage(e.icon, popIconColor) : null,
-            items: this.arrayToTouchBarElements(e.elements)
-          }))
-          break;
-
-        case "scrubber":
-          myTouchBarElements.push(new TouchBarScrubber({
-            items: emojis,
-            select: (i) => {
-              atom.workspace.getActiveTextEditor().insertText(emojis[i].label)
-            },
-            selectedStyle: "outline",
-            overlayStyle: "outline",
-            continuous: false
-          }))
-          break;
-
-      }
-    })
-
-    return new TouchBar(myTouchBarElements)
   }
 };

--- a/lib/touchbar.js
+++ b/lib/touchbar.js
@@ -30,6 +30,8 @@ export default {
   },
 
   activate() {
+    require('atom-package-deps').install('touchbar');
+    
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable();
 

--- a/menus/touchbar.json
+++ b/menus/touchbar.json
@@ -1,12 +1,4 @@
 {
-  "context-menu": {
-    "atom-text-editor": [
-      {
-        "label": "Toggle touchbar",
-        "command": "touchbar:toggle"
-      }
-    ]
-  },
   "menu": [
     {
       "label": "Packages",
@@ -14,10 +6,6 @@
         {
           "label": "touchbar",
           "submenu": [
-            {
-              "label": "Toggle",
-              "command": "touchbar:toggle"
-            },
             {
               "label": "Edit Touchbar",
               "command": "touchbar:edit"

--- a/package.json
+++ b/package.json
@@ -11,5 +11,15 @@
   },
   "dependencies": {
     "etch": "^0.12.4"
-  }
+  },
+  "consumedServices": {
+    "touchbar-registry": {
+      "versions": {
+        "0.1.0": "consumeTouchBar"
+      }
+    }
+  },
+  "package-deps": [
+    "touchbar-registry"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
+    "atom-package-deps": "^5.0.0",
     "etch": "^0.12.4"
   },
   "consumedServices": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,44 @@
 # yarn lockfile v1
 
 
+atom-package-deps@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/atom-package-deps/-/atom-package-deps-5.0.0.tgz#bd54b734b9288ed54a7b0b16995bf3ce7a45ca2f"
+  integrity sha512-C5Z2V68GuZvuLowrqQ8O8+BE8P4Elhxuc6eZiZ0770CH2e2R/Ausz5VebbDxVOSedFwAaz3CzQJYHayqZ5wKQg==
+  dependencies:
+    sb-fs "^3.0.0"
+    semver "^5.6.0"
+
 etch@^0.12.4:
   version "0.12.4"
   resolved "https://registry.yarnpkg.com/etch/-/etch-0.12.4.tgz#6c8b9500eeeda22a1e0962f58f94e2cf9573ac92"
+
+is-utf8@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+  integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
+
+sb-fs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sb-fs/-/sb-fs-3.0.0.tgz#fbdcdd3010e80a1b8e27490cef336064974203b8"
+  integrity sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g=
+  dependencies:
+    sb-promisify "^2.0.1"
+    strip-bom-buf "^1.0.0"
+
+sb-promisify@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/sb-promisify/-/sb-promisify-2.0.2.tgz#4277a54754488aa9675d886e354db894c9bdc981"
+  integrity sha1-QnelR1RIiqlnXYhuNU24lMm9yYE=
+
+semver@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+strip-bom-buf@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz#1cb45aaf57530f4caf86c7f75179d2c9a51dd572"
+  integrity sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=
+  dependencies:
+    is-utf8 "^0.2.1"


### PR DESCRIPTION
This change allows the `touchbar` package to work along side other packages that use the touchbar by coordinating through [`touchbar-registry`](https://atom.io/packages/touchbar-registry).

Toggle has been removed since the use-case no longer exists.