### PR TITLE
Improve support for segmented controls

### DIFF
--- a/lib/touchbar.js
+++ b/lib/touchbar.js
@@ -91,7 +91,10 @@ export default {
     let tbev = new TouchbarEditView(EditViewURI)
     atom.workspace.open(tbev)
   },
-
+  doCommand(command) {
+    var activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
+    atom.commands.dispatch(activeElement, command);
+  },
   arrayToTouchBarElements(input) {
     let elements = typeof input === 'string' ? JSON.parse(input) : input;
     let myTouchBarElements = []
@@ -111,10 +114,7 @@ export default {
           myTouchBarElements.push(new TouchBarButton({
             label: e.label,
             icon: e.icon ? e.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(e.icon, iconColor) : nativeImage.createFromPath(e.icon) : null,
-            click: () => {
-              var activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
-              atom.commands.dispatch(activeElement, e.command);
-            },
+            click: () => this.doCommand(e.command),
             // apply selected color only when there is one specified in config, otherwise use default color
             backgroundColor: (e.color
               ? e.color
@@ -186,7 +186,11 @@ export default {
             segments: e.elements.map(c => ({
               label: c.label,
               icon: c.icon ? c.icon.indexOf('/') == -1? nativeImage.createFromNamedImage(c.icon, c.iconColor) : nativeImage.createFromPath(c.icon) : null,
-            }))
+            })),
+            change: (selectedIndex) => {
+              this.doCommand(e.elements[selectedIndex].command)
+            },
+            mode: e.mode
           }))
           break;
 


### PR DESCRIPTION
Now you can change the mode, and trigger commands when a segment is 
selected using "command": definitions in each segment

Example: {"type":"segment","mode":"buttons","elements":[{"label":"Git","command":"github:toggle-git-tab"},{"label":"Hub","command":"github:toggle-github-tab"}]}