### PR TITLE
Fixed require lines to mach new electron requirements

### DIFF
--- a/lib/touchbar-edit-view.js
+++ b/lib/touchbar-edit-view.js
@@ -3,7 +3,7 @@
 
 import {Disposable} from 'atom'
 import etch from 'etch'
-const {app, BrowserWindow, TouchBar, nativeImage} = require('remote')
+const {app, BrowserWindow, TouchBar, nativeImage} = require('electron').remote
 const {TouchBarLabel, TouchBarButton, TouchBarSpacer, TouchBarSlider} = TouchBar
 
 import TouchBarItem from './touchbar-item'

--- a/lib/touchbar.js
+++ b/lib/touchbar.js
@@ -3,7 +3,7 @@
 import TouchbarEditView from './touchbar-edit-view';
 import {CompositeDisposable} from 'atom';
 
-const {app, BrowserWindow, TouchBar, Point, Range, nativeImage} = require('remote')
+const {app, BrowserWindow, TouchBar, Point, Range, nativeImage} = require('electron').remote
 
 const {
   TouchBarButton,


### PR DESCRIPTION
Atom's latest update (1.56.0) triggered a warning regarding the wrong use of the require line for electron's `remote` API. 
Upon opening Atom with the package installed and active (and only when active), this warning was shown at the bottom:
<img src="https://user-images.githubusercontent.com/6208377/117688317-5783ec00-b1c1-11eb-9bc9-f336d35ecf7d.png" width="200">
Which, when opened, showed this:
<img src="https://user-images.githubusercontent.com/6208377/117688401-68ccf880-b1c1-11eb-9484-660ec42ce1bf.png" width="400">


The PR only fixes the code for the requirement. I tested it locally with no other warning or error being shown.
